### PR TITLE
Make code samples readable in light mode by using a black background

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ Please ensure you have the following installed:
 Clone this repo, and the Book theme as a submodule:
 
 ```console
-$ git clone --recurse-submodules --depth 1 git@github.com:regolith-linux/regolith-desktop-website.git regolith-desktop-website
-$ cd regolith-desktop-website
+$ git clone --recurse-submodules --depth 1 git@github.com:regolith-linux/regolith-desktop.com.git regolith-desktop.com
+$ cd regolith-desktop.com
 ```
 
-Install dependencies and launch Hugo server:
+Launch the Hugo server:
 
 ```console
-$ npm install
 $ hugo server
 ```
 

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -44,146 +44,146 @@ img {
       transition: none;
     }
   }
-  
+
   a.badge:hover, a.badge:focus {
     text-decoration: none;
   }
-  
+
   .badge:empty {
     display: none;
   }
-  
+
   .btn .badge {
     position: relative;
     top: -1px;
   }
-  
+
   .badge-pill {
     padding-right: 0.6em;
     padding-left: 0.6em;
     border-radius: 10rem;
   }
-  
+
   .badge-primary {
     color: #fff;
     background-color: #007bff;
   }
-  
+
   a.badge-primary:hover, a.badge-primary:focus {
     color: #fff;
     background-color: #0062cc;
   }
-  
+
   a.badge-primary:focus, a.badge-primary.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);
   }
-  
+
   .badge-secondary {
     color: #fff;
     background-color: #6c757d;
   }
-  
+
   a.badge-secondary:hover, a.badge-secondary:focus {
     color: #fff;
     background-color: #545b62;
   }
-  
+
   a.badge-secondary:focus, a.badge-secondary.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);
   }
-  
+
   .badge-success {
     color: #fff;
     background-color: #28a745;
   }
-  
+
   a.badge-success:hover, a.badge-success:focus {
     color: #fff;
     background-color: #1e7e34;
   }
-  
+
   a.badge-success:focus, a.badge-success.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5);
   }
-  
+
   .badge-info {
     color: #fff;
     background-color: #17a2b8;
   }
-  
+
   a.badge-info:hover, a.badge-info:focus {
     color: #fff;
     background-color: #117a8b;
   }
-  
+
   a.badge-info:focus, a.badge-info.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);
   }
-  
+
   .badge-warning {
     color: #212529;
     background-color: #ffc107;
   }
-  
+
   a.badge-warning:hover, a.badge-warning:focus {
     color: #212529;
     background-color: #d39e00;
   }
-  
+
   a.badge-warning:focus, a.badge-warning.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);
   }
-  
+
   .badge-danger {
     color: #fff;
     background-color: #dc3545;
   }
-  
+
   a.badge-danger:hover, a.badge-danger:focus {
     color: #fff;
     background-color: #bd2130;
   }
-  
+
   a.badge-danger:focus, a.badge-danger.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5);
   }
-  
+
   .badge-light {
     color: #212529;
     background-color: #f8f9fa;
   }
-  
+
   a.badge-light:hover, a.badge-light:focus {
     color: #212529;
     background-color: #dae0e5;
   }
-  
+
   a.badge-light:focus, a.badge-light.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5);
   }
-  
+
   .badge-dark {
     color: #fff;
     background-color: #343a40;
   }
-  
+
   a.badge-dark:hover, a.badge-dark:focus {
     color: #fff;
     background-color: #1d2124;
   }
-  
+
   a.badge-dark:focus, a.badge-dark.focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5);
   }
-  
+
 .highlight > pre {
-  background: var(--gray-100) !important;
+  background: black !important;
 }


### PR DESCRIPTION
I couldn't read some of the instructions in light mode; before this change, code samples were white-on-white (rather, #f8f8f2 on --gray-100 (#f8f9fa)). This branch unconditionally sets the background to black for code samples.

(If you'd prefer theme-specific colours, do change things on the branch; "allow edits by maintainers" should be checked.)

It also updates the readme to reflect the change in repository name and the absence of any JavaScript.

---

# Before

## Dark mode

![maim-2025-02-01T11-17-31](https://github.com/user-attachments/assets/d4a79697-f802-43c8-b87f-a319f3ef6be9)

## Light mode

![maim-2025-02-01T11-17-43](https://github.com/user-attachments/assets/504affaf-ba8a-4dff-a091-c727a609cb01)

# After

## Dark mode

![maim-2025-02-01T11-14-33](https://github.com/user-attachments/assets/28f4ca5d-7f9a-495d-ac0f-6ad1aa3472ce)

## Light mode

![maim-2025-02-01T11-14-46](https://github.com/user-attachments/assets/c251e3b4-453c-4880-8e5d-ed849d4bea1e)