### PR TITLE
chore: callout the repo key for visibility

### DIFF
--- a/content/posts/repo-url-change-3.3.md
+++ b/content/posts/repo-url-change-3.3.md
@@ -28,7 +28,9 @@ deb [arch=amd64] https://archive.regolith-desktop.com/ubuntu/stable noble main
           * Architecture
 ```
 
+{{< callout type="info" >}}
 All other aspects of the package configuration remain the same including the key used to verify packages.
+{{< /callout >}}
 
 ### Architecture
 


### PR DESCRIPTION
Put information about repo key in a `callout` for visibility.